### PR TITLE
Fix multi word options

### DIFF
--- a/lib/search_object/plugin/graphql.rb
+++ b/lib/search_object/plugin/graphql.rb
@@ -29,6 +29,10 @@ module SearchObject
         KEYS = %i[type default description].freeze
         def option(name, options = {}, &block)
           config[:arguments] ||= {}
+
+          name = name.split('_').map(&:capitalize).join
+          name[0] = name[0].downcase!
+
           config[:arguments][name.to_s] = KEYS.inject({}) do |acc, key|
             acc[key] = options[key] if options.key?(key)
             acc
@@ -135,6 +139,12 @@ module SearchObject
         def initialize(name)
           super "GraphQL type has to passed as :type to '#{name}' option"
         end
+      end
+
+      private
+
+      def camelize(string)
+
       end
     end
   end

--- a/lib/search_object/plugin/graphql.rb
+++ b/lib/search_object/plugin/graphql.rb
@@ -31,7 +31,7 @@ module SearchObject
           config[:arguments] ||= {}
 
           name = name.split('_').map(&:capitalize).join
-          name[0] = name[0].downcase!
+          name[0] = name[0].downcase
 
           config[:arguments][name.to_s] = KEYS.inject({}) do |acc, key|
             acc[key] = options[key] if options.key?(key)

--- a/lib/search_object/plugin/graphql.rb
+++ b/lib/search_object/plugin/graphql.rb
@@ -30,10 +30,10 @@ module SearchObject
         def option(name, options = {}, &block)
           config[:arguments] ||= {}
 
-          name = name.split('_').map(&:capitalize).join
+          name = name.to_s.split('_').map(&:capitalize).join
           name[0] = name[0].downcase
 
-          config[:arguments][name.to_s] = KEYS.inject({}) do |acc, key|
+          config[:arguments][name] = KEYS.inject({}) do |acc, key|
             acc[key] = options[key] if options.key?(key)
             acc
           end

--- a/lib/search_object/plugin/graphql.rb
+++ b/lib/search_object/plugin/graphql.rb
@@ -140,12 +140,6 @@ module SearchObject
           super "GraphQL type has to passed as :type to '#{name}' option"
         end
       end
-
-      private
-
-      def camelize(string)
-
-      end
     end
   end
 end


### PR DESCRIPTION
Fixes multi-word option names not working. 
Example:
```ruby
option(:qa_permissions, type: String,  description: 'qa_permissions_description', with: :apply_qa_permissions_filter)
```
Would always throw an exception:
```
undefined method `type' for nil:NilClass
.rvm/gems/ruby-2.6.3/gems/graphql-1.9.12/lib/graphql/execution/interpreter/runtime.rb:452:in `block in arguments'
```