### PR TITLE
Support enums with specified values

### DIFF
--- a/lib/search_object/plugin/graphql.rb
+++ b/lib/search_object/plugin/graphql.rb
@@ -35,7 +35,7 @@ module SearchObject
           end
 
           type = options.fetch(:type) { raise MissingTypeDefinitionError, name }
-          options[:enum] = type.values.keys if type.respond_to?(:values)
+          options[:enum] = type.values.map { |value, enum_value| enum_value.value || value } if type.respond_to?(:values)
 
           super(name, options, &block)
         end


### PR DESCRIPTION
https://graphql-ruby.org/type_definitions/enums.html

When `value:` is used with `Enums` as mentioned above it breaks the functionality of filtering requests by it. This and a small fix in https://github.com/RStankov/SearchObject does fix the problem.