### PR TITLE
Add support for camelize option

### DIFF
--- a/lib/search_object/plugin/graphql.rb
+++ b/lib/search_object/plugin/graphql.rb
@@ -26,7 +26,7 @@ module SearchObject
       end
 
       module ClassMethods
-        KEYS = %i[type default description required].freeze
+        KEYS = %i[type default description required camelize].freeze
         def option(name, options = {}, &block)
           config[:arguments] ||= {}
           config[:arguments][name.to_s] = KEYS.inject({}) do |acc, key|
@@ -100,14 +100,17 @@ module SearchObject
             resolver_class: self,
             deprecation_reason: deprecation_reason,
             arguments: (config[:arguments] || {}).inject({}) do |acc, (name, options)|
-              name = name.to_s.split('_').map(&:capitalize).join
-              name[0] = name[0].downcase
+              if options.fetch(:camelize) { true }
+                name = name.to_s.split('_').map(&:capitalize).join
+                name[0] = name[0].downcase
+              end
 
               acc[name] = ::GraphQL::Schema::Argument.new(
                 name: name.to_s,
                 type: options.fetch(:type) { raise MissingTypeDefinitionError, name },
                 description: options[:description],
                 required: !!options[:required],
+                camelize: !!options[:camelize],
                 default_value: options.fetch(:default) { ::GraphQL::Schema::Argument::NO_DEFAULT },
                 owner: self
               )

--- a/spec/search_object/plugin/graphql_spec.rb
+++ b/spec/search_object/plugin/graphql_spec.rb
@@ -362,6 +362,40 @@ describe SearchObject::Plugin::Graphql do
       )
     end
 
+    it 'accepts camelize' do
+      schema = define_search_class_and_return_schema do
+        type PostType
+
+        option('option_field', type: types.String, camelize: false)
+      end
+
+      result = schema.execute <<-SQL
+        {
+          __type(name: "Query") {
+            name
+            fields {
+              args {
+                name
+              }
+            }
+          }
+        }
+      SQL
+
+      expect(result.to_h).to eq(
+        'data' => {
+          '__type' => {
+            'name' => 'Query',
+            'fields' => [{
+              'args' => [{
+                'name' => 'option_field'
+              }]
+            }]
+          }
+        }
+      )
+    end
+
     it 'raises error when no type is given' do
       expect { define_search_class { option :name } }.to raise_error described_class::MissingTypeDefinitionError
     end


### PR DESCRIPTION
Currently, it's not possible to use snake cased arguments. This adds support for the camelize option. It will default to camel case argument names if nothing is provided.