### PR TITLE
Don't override graphql-ruby's defaults for options that weren't specified, and pass default_value to argument when default option is specified

### DIFF
--- a/lib/search_object/plugin/graphql.rb
+++ b/lib/search_object/plugin/graphql.rb
@@ -31,12 +31,14 @@ module SearchObject
           type = options.fetch(:type) { raise MissingTypeDefinitionError, name }
           options[:enum] = type.values.map { |value, enum_value| enum_value.value || value } if type.respond_to?(:values)
 
+          argument_options = { required: options[:required] || false }
+          argument_options[:camelize] = options[:camelize] if options.include?(:camelize)
+          argument_options[:description] = options[:description] if options.include?(:description)
+
           argument(
             name.to_s,
             options[:type],
-            required: options[:required] || false,
-            description: options[:description],
-            camelize: options[:camelize]
+            **argument_options
           )
 
           super(name, options, &block)

--- a/lib/search_object/plugin/graphql.rb
+++ b/lib/search_object/plugin/graphql.rb
@@ -33,6 +33,7 @@ module SearchObject
 
           argument_options = { required: options[:required] || false }
           argument_options[:camelize] = options[:camelize] if options.include?(:camelize)
+          argument_options[:default_value] = options[:default] if options.include?(:default)
           argument_options[:description] = options[:description] if options.include?(:description)
 
           argument(

--- a/spec/search_object/plugin/graphql_spec.rb
+++ b/spec/search_object/plugin/graphql_spec.rb
@@ -217,6 +217,42 @@ describe SearchObject::Plugin::Graphql do
       )
     end
 
+    it 'sets default_value on the argument' do
+      schema = define_search_class_and_return_schema do
+        type PostType, null: true
+
+        option('option', type: types.String, default: 'default') { [] }
+      end
+
+      result = schema.execute <<~GRAPHQL
+        {
+          __type(name: "Query") {
+            name
+            fields {
+              args {
+                name
+                defaultValue
+              }
+            }
+          }
+        }
+      GRAPHQL
+
+      expect(result).to eq(
+        'data' => {
+          '__type' => {
+            'name' => 'Query',
+            'fields' => [{
+              'args' => [{
+                'name' => 'option',
+                'defaultValue' => '"default"'
+              }]
+            }]
+          }
+        }
+      )
+    end
+
     it 'accepts "required"' do
       schema = define_search_class_and_return_schema do
         option(:id, type: types.String, required: true) do |_scope, value|

--- a/spec/search_object/plugin/graphql_spec.rb
+++ b/spec/search_object/plugin/graphql_spec.rb
@@ -299,6 +299,40 @@ describe SearchObject::Plugin::Graphql do
       )
     end
 
+    it 'does not override the default camelize option' do
+      schema = define_search_class_and_return_schema do
+        type PostType, null: true
+
+        option('option_field', type: types.String)
+      end
+
+      result = schema.execute <<~GRAPHQL
+        {
+          __type(name: "Query") {
+            name
+            fields {
+              args {
+                name
+              }
+            }
+          }
+        }
+      GRAPHQL
+
+      expect(result.to_h).to eq(
+        'data' => {
+          '__type' => {
+            'name' => 'Query',
+            'fields' => [{
+              'args' => [{
+                'name' => 'optionField'
+              }]
+            }]
+          }
+        }
+      )
+    end
+
     it 'raises error when no type is given' do
       expect { define_search_class { option :name } }.to raise_error described_class::MissingTypeDefinitionError
     end


### PR DESCRIPTION
Fixes #30 
Fixes #31