### PR TITLE
Add an opportunity to mark argument as deprecated

### DIFF
--- a/lib/search_object/plugin/graphql.rb
+++ b/lib/search_object/plugin/graphql.rb
@@ -37,6 +37,7 @@ module SearchObject
           argument_options[:camelize] = options[:camelize] if options.include?(:camelize)
           argument_options[:default_value] = options[:default] if options.include?(:default)
           argument_options[:description] = options[:description] if options.include?(:description)
+          argument_options[:deprecation_reason] = options[:deprecation_reason] if options.include?(:deprecation_reason)
 
           argument(name.to_s, type, **argument_options)
 

--- a/spec/search_object/plugin/graphql_spec.rb
+++ b/spec/search_object/plugin/graphql_spec.rb
@@ -410,6 +410,41 @@ describe SearchObject::Plugin::Graphql do
       )
     end
 
+    it 'accepts deprecation_reson' do
+      schema = define_search_class_and_return_schema do
+        type PostType, null: true
+
+        option('option', type: String, deprecation_reson: 'Not in use anymore')
+      end
+
+      result = schema.execute <<-SQL
+        {
+          __type(name: "Query") {
+            name
+            fields {
+              args {
+                name
+              }
+            }
+          }
+        }
+      SQL
+
+      # it will work, but there won't be in schema
+      expect(result.to_h).to eq(
+        'data' => {
+          '__type' => {
+            'name' => 'Query',
+            'fields' => [{
+              'args' => [{
+                'name' => 'option'
+              }]
+            }]
+          }
+        }
+      )
+    end
+
     it 'raises error when no type is given' do
       expect { define_search_class { option :name } }.to raise_error described_class::MissingTypeDefinitionError
     end

--- a/spec/search_object/plugin/graphql_spec.rb
+++ b/spec/search_object/plugin/graphql_spec.rb
@@ -410,11 +410,11 @@ describe SearchObject::Plugin::Graphql do
       )
     end
 
-    it 'accepts deprecation_reson' do
+    it 'accepts deprecation_reason' do
       schema = define_search_class_and_return_schema do
         type PostType, null: true
 
-        option('option', type: String, deprecation_reson: 'Not in use anymore')
+        option('option', type: String, deprecation_reason: 'Not in use anymore')
       end
 
       result = schema.execute <<-SQL


### PR DESCRIPTION
Good to have an opportunity to mark `argument` inside of `option` as deprecated